### PR TITLE
Used bit packing for evaluating ARM condition codes instead of a switch-case

### DIFF
--- a/src/crab/arm/arm.cr
+++ b/src/crab/arm/arm.cr
@@ -10,6 +10,7 @@ module ARM
       lut[hash].call instr
     else
       log "Skipping instruction, cond: #{hex_str instr >> 28}"
+      raise "Condition code NV" if bits(instr, 28..31) == 0xF
       step_arm
     end
   end

--- a/src/crab/arm/branch_exchange.cr
+++ b/src/crab/arm/branch_exchange.cr
@@ -1,11 +1,7 @@
 module ARM
   def arm_branch_exchange(instr : Word) : Nil
     rn = bits(instr, 0..3)
-    if bit?(@r[rn], 0)
-      @cpsr.thumb = true
-      set_reg(15, @r[rn])
-    else
-      set_reg(15, @r[rn])
-    end
+    @cpsr.thumb = bit?(@r[rn], 0) 
+    set_reg(15, @r[rn])
   end
 end


### PR DESCRIPTION
This PR gains a couple FPS depending on the scene in emerald in my VM, tell me if you get any benefit from it

The truthfulness of an ARM condition depends on 2 factors:
- The condition code (4 bits)
- The upper 4 CPSR bits
This means that you can use a 256-entry truth table that uses the upper 8 bits as a hash, instead of using a switch-case which would probably compile to an array lookup + indirect jump.

LUTs aren't generally the best thing for the cache and stuff, so they shouldn't be abused toooo much.  So, here's a neat bit packing trick which originates from MelonDS's ARM interpreter, which uses a packed 32 (16*2) byte LUT of masks depending on the condition code, instead of a switch-case, to verify if a condition is true. The 16 masks in the LUT are magic numbers which get masked by (1 << CPSR_FLAGS). The masks are specially-made so that `masks [conditionCode] & (1 << CPSR_FLAGS)` will always return a non-zero value if the condition is met, and 0 if not. This way, you can 
- Minimize the dcache overhead of a 256-byte truth table by tightly packing it (32 bytes are fewer than 256 :p)
- Not use a switch-case

I used Pokemon Emerald to make sure it works and arm.gba wihch still passes. 
I tried ARMWrestler too but I couldn't find the start button. It boots though.
~~Tell me what you think when you can~~